### PR TITLE
use init_db in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,7 @@ redis-server &
 celery -A plenario.celery_app worker --loglevel=info &
 ```
 
-Initialize the plenario database: 
-
-```
-python
->>> from plenario import database
->>> database.init_db()
-```
+Initialize the plenario database by running `python init_db.py`. 
 
 Finally, run the server:
 


### PR DESCRIPTION
Since we added the init_db script for the Dockerfile, might as well use it for the the setup instructions because saves the user a step. 
