### PR TITLE
Shape meta

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -6,7 +6,6 @@ from plenario.tasks import hello_world
 from plenario.utils.weather import WeatherETL, WeatherStationsETL
 from argparse import ArgumentParser
 
-
 def init_db(args):
     if not any(vars(args).values()):
         # No specific arguments specified. Run it all!

--- a/plenario/models.py
+++ b/plenario/models.py
@@ -306,6 +306,10 @@ class ShapeMetadata(Base):
     human_name = Column(String, nullable=False)
     source_url = Column(String)
     date_added = Column(Date, nullable=False)
+
+    # Organization that published this dataset
+    attribution = Column(String)
+
     # We always ingest geometric data as 4326
     bbox = Column(Geometry('POLYGON', srid=4326))
     # How many shape records are present?
@@ -343,9 +347,11 @@ class ShapeMetadata(Base):
                                       cls.human_name,
                                       cls.date_added,
                                       func.ST_AsGeoJSON(cls.bbox),
-                                      cls.num_shapes)\
+                                      cls.num_shapes,
+                                      cls.attribution
+                                      )\
                                  .filter(cls.is_ingested)
-        field_names = ['dataset_name', 'human_name', 'date_added', 'bounding_box', 'num_shapes']
+        field_names = ['dataset_name', 'human_name', 'date_added', 'bounding_box', 'num_shapes', 'attribution']
         listing = [dict(zip(field_names, row)) for row in result]
         for dataset in listing:
             dataset['date_added'] = str(dataset['date_added'])
@@ -373,10 +379,11 @@ class ShapeMetadata(Base):
         return slugify(human_name)
 
     @classmethod
-    def add(cls, caller_session, human_name, source_url):
+    def add(cls, caller_session, human_name, source_url, attribution):
         table_name = ShapeMetadata.make_table_name(human_name)
         new_shape_dataset = ShapeMetadata(dataset_name=table_name,
                                           human_name=human_name,
+                                          attribution = attribution,
                                           is_ingested=False,
                                           source_url=source_url,
                                           date_added=datetime.now().date(),

--- a/plenario/static/js/explore/templates/shapesList.html
+++ b/plenario/static/js/explore/templates/shapesList.html
@@ -4,6 +4,7 @@
 <table id='shape-datasets' class='table table-condensed'>
     <thead>
     <tr>
+        <th>Source</th>
         <th>Dataset Name</th>
           <% if (hasIntersect) { %>
             <th>Count</th>
@@ -15,6 +16,7 @@
     <tbody>
     <% $.each(shapes, function(i, shape){ %>
         <tr>
+            <td><%= shape.attribution %></td>
             <td><%= shape.human_name %></td>
             <% if (hasIntersect) { %>
             <td><%= shape.num_geoms %></td>

--- a/plenario/templates/submit-shape.html
+++ b/plenario/templates/submit-shape.html
@@ -25,6 +25,16 @@
                                     error_message="Please select a name."
                                     ) }}
 
+        {{ bootstrap_validate_field(type="text",
+                                    name="attribution",
+                                    description="Source that publishes this dataset",
+                                    placeholder="Public or Private Organization",
+                                    help_message="",
+                                    error_message="Please enter a source."
+                                    ) }}
+        
+        {# add fields to form, change model, add backend code for storage #}
+
         <div class="form-group">
             <button type="submit" class="btn btn-primary">Add Shapefile</button>
         </div>

--- a/plenario/templates/submit-shape.html
+++ b/plenario/templates/submit-shape.html
@@ -33,8 +33,6 @@
                                     error_message="Please enter a source."
                                     ) }}
         
-        {# add fields to form, change model, add backend code for storage #}
-
         <div class="form-group">
             <button type="submit" class="btn btn-primary">Add Shapefile</button>
         </div>

--- a/plenario/views.py
+++ b/plenario/views.py
@@ -117,6 +117,7 @@ def get_context_for_new_dataset(url):
     return (dataset_info, errors, socrata_source)
 
 def table_row_estimate(table_name):
+    print table_name, "estimating"
     try:
         q = text(''' 
             SELECT reltuples::bigint AS estimate FROM pg_class where relname=:table_name;
@@ -282,6 +283,8 @@ def add_table():
         dataset_info['contributor_organization'] = 'Plenario Admin'
         dataset_info['contributor_email'] = user.email
 
+        print dataset_info
+
         # check if dataset with the same URL has already been loaded
         dataset_id = md5(url).hexdigest()
         md = session.query(MetaTable).get(dataset_id)
@@ -314,6 +317,7 @@ def add_shape():
         try:
             human_name = request.form['dataset_name']
             source_url = request.form['source_url']
+            attribution  = request.form['attribution']
         except KeyError:
             # Front-end validation failed or someone is posting bogus query strings directly.
             # re-render with error message
@@ -325,7 +329,9 @@ def add_shape():
 
         if not errors:
             # Add the metadata right away
-            meta = ShapeMetadata.add(caller_session=session, human_name=human_name, source_url=source_url)
+            # Add some kind of ingestion method to examine shape url and grab metadata
+            # shape_info = get_context_for_new_shape(url)
+            meta = ShapeMetadata.add(caller_session=session, human_name=human_name, source_url=source_url, attribution = attribution)
             session.commit()
 
             # And tell a worker to go ingest it

--- a/plenario/views.py
+++ b/plenario/views.py
@@ -117,7 +117,6 @@ def get_context_for_new_dataset(url):
     return (dataset_info, errors, socrata_source)
 
 def table_row_estimate(table_name):
-    print table_name, "estimating"
     try:
         q = text(''' 
             SELECT reltuples::bigint AS estimate FROM pg_class where relname=:table_name;
@@ -282,8 +281,6 @@ def add_table():
         dataset_info['contributor_name'] = user.name
         dataset_info['contributor_organization'] = 'Plenario Admin'
         dataset_info['contributor_email'] = user.email
-
-        print dataset_info
 
         # check if dataset with the same URL has already been loaded
         dataset_id = md5(url).hexdigest()


### PR DESCRIPTION
Now the admin has to specify a source when submitting a shape dataset. The source is stored on the backend in an 'attribution' column in the meta_shape table. The source is also now displayed in the explore view as a column of the shapes list.