### PR TITLE
Render available days

### DIFF
--- a/plenario/static/js/explore/views/about-view.js
+++ b/plenario/static/js/explore/views/about-view.js
@@ -7,6 +7,7 @@ var AboutView = Backbone.View.extend({
     },
     render: function(){
         $('#list-view').show();
+        $('#shapes-view').show();
         $('#detail-view').hide();
         this.$el.empty();
         this.$el.spin('large');
@@ -50,7 +51,7 @@ var AboutView = Backbone.View.extend({
         })
     },
     detailView: function(e){
-        console.log('about-view detailView');
+        //console.log('about-view detailView');
         var query = {};
         var start = $('#start-date-filter').val();
         var end = $('#end-date-filter').val();

--- a/plenario/static/js/explore/views/about-view.js
+++ b/plenario/static/js/explore/views/about-view.js
@@ -51,7 +51,6 @@ var AboutView = Backbone.View.extend({
         })
     },
     detailView: function(e){
-        //console.log('about-view detailView');
         var query = {};
         var start = $('#start-date-filter').val();
         var end = $('#end-date-filter').val();

--- a/plenario/static/js/explore/views/detail-view.js
+++ b/plenario/static/js/explore/views/detail-view.js
@@ -10,17 +10,32 @@ var DetailView = Backbone.View.extend({
         this.meta = this.attributes.meta;
         this.filters = this.attributes.filters;
 
+        // set up the start and end date to a 90 day windows from today
         var start = moment().subtract('d', 90).format('MM/DD/YYYY');
         var end = moment().format('MM/DD/YYYY');
 
+        var obs_from = moment(this.meta.obs_from).format('MM/DD/YYYY');
+        var obs_to = moment(this.meta.obs_to).format('MM/DD/YYYY');
+
+        // if the query has dates we use the user-specified start and end dates
         if (this.query) {
             start = moment(this.query.obs_date__ge).format('MM/DD/YYYY');
             end = moment(this.query.obs_date__le).format('MM/DD/YYYY');
         }
 
+        // if the user hasn't made a query set the start and end dates to obs_to and 90 days before
+        // to render available data
+        if (typeof this.query['location_geom__within'] == 'undefined') {
+            if (moment(start).isAfter(obs_to) || moment(end).isBefore(obs_from)) {
+                start = moment(obs_to).subtract('d',90).format('MM/DD/YYYY');
+                end = obs_to;
+                this.query.obs_date__ge = moment(obs_to).subtract('d',90).format('YYYY/MM/DD');
+                this.query.obs_date__le = moment(this.meta.obs_to).format('YYYY/MM/DD');
+            }
+        }
+
         if (typeof this.query['agg'] == 'undefined')
             this.query['agg'] = "week";
-
         if (typeof this.query['resolution'] == 'undefined')
             this.query['resolution'] = "500";
         this.points_query = $.extend(true, {}, this.query);
@@ -250,7 +265,6 @@ var DetailView = Backbone.View.extend({
         this.query = query;
         if(valid){
             this.undelegateEvents();
-            // console.log(this.query)
             new DetailView({el: '#map-view', attributes: {query: query, meta: this.meta}})
             var route = 'detail/' + $.param(query)
             _gaq.push(['_trackPageview', route]);
@@ -266,29 +280,39 @@ var DetailView = Backbone.View.extend({
     },
 
     backToExplorer: function(e){
-        //this function needs to get fixed
+
         e.preventDefault();
         this.undelegateEvents();
         var points_query = this.points_query;
+        var attrs = {resp: resp}
+        console.log(attrs)
 
-        // delete filters and dataset name from query
+
+        if (typeof points_query['location_geom__within'] !== 'undefined'){
+            attrs['dataLayer'] = $.parseJSON(points_query['location_geom__within']);
+        } else {
+            // if the user hasn't done any filtering go back to index
+            if (_.isEmpty(self.filters)) {
+                new AboutView({el: '#list-view'});
+                shapeView = new app.ShapeView({el: '#shapes-view'});
+                map = new MapView({el: '#map-view', attributes: attrs})
+                console.log("back to index")
+                _gaq.push(['_trackPageview', ""]);
+                router.navigate("");
+                return;
+            }
+        }
+
+        // clean up query
         delete points_query['dataset_name'];
-
         $.each(self.filters, function(key, val){
             delete points_query[key];
         });
 
-        //if we've made a query go back to that aggregate view
-        if (resp) { resp.undelegateEvents(); }
-        //if not use the initial query to render results which is why it's not rendering all the available datasets
-        resp = new ResponseView({el: '#list-view', attributes: {query: points_query}});
-        var attrs = { resp: resp }
-        if (typeof points_query['location_geom__within'] !== 'undefined'){
-            attrs['dataLayer'] = $.parseJSON(points_query['location_geom__within']);
-        }
-
         if (map) { map.undelegateEvents(); }
         map = new MapView({el: '#map-view', attributes: attrs});
+        if (resp) { resp.undelegateEvents(); }
+        resp = new ResponseView({el: '#list-view', attributes: {query: points_query}});
         var route = "aggregate/" + $.param(points_query);
         _gaq.push(['_trackPageview', route]);
         router.navigate(route);
@@ -317,7 +341,7 @@ var DetailView = Backbone.View.extend({
     getFields: function(){
         var q = this.getQuery()
         return $.ajax({
-            url: ('/v1/api/fields/' + q['dataset_name'])
+            url: '/v1/api/fields/' + q['dataset_name']
         })
     },
     getCutoffs: function(values){

--- a/plenario/static/js/explore/views/detail-view.js
+++ b/plenario/static/js/explore/views/detail-view.js
@@ -17,7 +17,7 @@ var DetailView = Backbone.View.extend({
         var obs_from = moment(this.meta.obs_from).format('MM/DD/YYYY');
         var obs_to = moment(this.meta.obs_to).format('MM/DD/YYYY');
 
-        // if the query has dates we use the user-specified start and end dates
+        // if the query has dates we use the user-specified start and end dates for display
         if (this.query) {
             start = moment(this.query.obs_date__ge).format('MM/DD/YYYY');
             end = moment(this.query.obs_date__le).format('MM/DD/YYYY');
@@ -285,8 +285,6 @@ var DetailView = Backbone.View.extend({
         this.undelegateEvents();
         var points_query = this.points_query;
         var attrs = {resp: resp}
-        console.log(attrs)
-
 
         if (typeof points_query['location_geom__within'] !== 'undefined'){
             attrs['dataLayer'] = $.parseJSON(points_query['location_geom__within']);
@@ -296,7 +294,6 @@ var DetailView = Backbone.View.extend({
                 new AboutView({el: '#list-view'});
                 shapeView = new app.ShapeView({el: '#shapes-view'});
                 map = new MapView({el: '#map-view', attributes: attrs})
-                console.log("back to index")
                 _gaq.push(['_trackPageview', ""]);
                 router.navigate("");
                 return;

--- a/plenario/static/js/explore/views/filter-view.js
+++ b/plenario/static/js/explore/views/filter-view.js
@@ -3,7 +3,6 @@ var FilterView = Backbone.View.extend({
         'click .remove-filter': 'clear'
     },
     initialize: function(){
-        console.log(this.attributes);
         this.filter_dict = this.attributes.filter_dict;
         this.field_options = this.attributes.field_options;
         this.render();

--- a/plenario/static/js/explore/views/filter-view.js
+++ b/plenario/static/js/explore/views/filter-view.js
@@ -3,7 +3,7 @@ var FilterView = Backbone.View.extend({
         'click .remove-filter': 'clear'
     },
     initialize: function(){
-        // console.log(this.attributes);
+        console.log(this.attributes);
         this.filter_dict = this.attributes.filter_dict;
         this.field_options = this.attributes.field_options;
         this.render();

--- a/plenario/static/js/explore/views/shape-detail-view.js
+++ b/plenario/static/js/explore/views/shape-detail-view.js
@@ -66,6 +66,13 @@ var app = app || {};
 
         if (typeof this.query['location_geom__within'] !== 'undefined'){
             attrs['dataLayer'] = $.parseJSON(this.query['location_geom__within']);
+        } else {
+            new AboutView({el: '#list-view'});
+            shapeView = new app.ShapeView({el: '#shapes-view'});
+            map = new MapView({el: '#map-view', attributes: attrs})
+            _gaq.push(['_trackPageview', ""]);
+            router.navigate("");
+            return;
         }
 
         if (resp) { resp.undelegateEvents(); }


### PR DESCRIPTION
Bug fixes
 - When the user goes back to the index list view the list of shapes will be on the index. 
Added behaviors
- If a user does not specify search dates and navigates to the detail page of a dataset and if there is no available data within the default dates (from 90 days ago to today), they will view the data that is available 90 days up to the last time the data is available. 
- If the user has not done any filtering on a dataset and returns to the explore page, we will go back to the list index view rather than the aggregate response view. 