### PR TITLE
Fix detail obs date

### DIFF
--- a/plenario/api/point.py
+++ b/plenario/api/point.py
@@ -359,9 +359,10 @@ def detail_query(args, aggregate=False):
 
 def _grid(args):
 
-    meta_params = ('dataset', 'geom', 'resolution', 'buffer')
+    meta_params = ('dataset', 'geom', 'resolution', 'buffer', 'obs_date__ge',
+                   'obs_date__le')
     meta_vals = (args.data.get(k) for k in meta_params)
-    point_table, geom, resolution, buffer_ = meta_vals
+    point_table, geom, resolution, buffer_, obs_date__ge, obs_date__le = meta_vals
 
     result_rows = []
 
@@ -386,7 +387,12 @@ def _grid(args):
         try:
             registry_row = MetaTable.get_by_dataset_name(table.name)
             # make_grid expects conditions to be iterable.
-            grid_rows, size_x, size_y = registry_row.make_grid(resolution, geom, [conditions])
+            grid_rows, size_x, size_y = registry_row.make_grid(
+                resolution,
+                geom,
+                [conditions],
+                {'upper': obs_date__le, 'lower': obs_date__ge}
+            )
             result_rows += grid_rows
         except Exception as e:
             return internal_error('Could not make grid aggregation.', e)

--- a/plenario/api/point.py
+++ b/plenario/api/point.py
@@ -295,9 +295,10 @@ def _detail(args):
 
 def detail_query(args, aggregate=False):
 
-    meta_params = ('dataset', 'shapeset', 'data_type', 'geom')
+    meta_params = ('dataset', 'shapeset', 'data_type', 'geom', 'obs_date__ge',
+                   'obs_date__le')
     meta_vals = (args.data.get(k) for k in meta_params)
-    dataset, shapeset, data_type, geom = meta_vals
+    dataset, shapeset, data_type, geom, obs_date__ge, obs_date__le = meta_vals
 
     # If there aren't tree filters provided, a little formatting is needed
     # to make the general filters into an 'and' tree.
@@ -331,6 +332,10 @@ def detail_query(args, aggregate=False):
     if point_ctree:
         point_conditions = parse_tree(dataset, point_ctree)
         q = q.filter(point_conditions)
+
+        # To allow both obs_date meta params and filter trees.
+        q = q.filter(dataset.c.point_date >= obs_date__ge) if obs_date__ge else q
+        q = q.filter(dataset.c.point_date <= obs_date__le) if obs_date__le else q
 
     # If a user specified a shape dataset, it was either through the /shapes
     # enpoint, which uses the aggregate result, or through the /detail endpoint

--- a/plenario/models.py
+++ b/plenario/models.py
@@ -289,7 +289,7 @@ class MetaTable(Base):
             self.date_added = now
         self.last_update = now
 
-    def make_grid(self, resolution, geom=None, conditions=None):
+    def make_grid(self, resolution, geom=None, conditions=None, obs_dates={}):
         """
         :param resolution: length of side of grid square in meters
         :type resolution: int
@@ -319,6 +319,10 @@ class MetaTable(Base):
                           .label('squares'))\
             .filter(*conditions)\
             .group_by('squares')
+
+        if obs_dates:
+            q = q.filter(t.c.point_date >= obs_dates['lower'])
+            q = q.filter(t.c.point_date <= obs_dates['upper'])
 
         if geom:
             q = q.filter(t.c.geom.ST_Within(func.ST_GeomFromGeoJSON(geom)))

--- a/tests/points/api_tests.py
+++ b/tests/points/api_tests.py
@@ -123,19 +123,19 @@ class PointAPITests(BasePlenarioTest):
     # ====================
 
     def test_detail_with_simple_flu_filter(self):
-        r = self.get_api_response('detail?dataset_name=flu_shot_clinics&' + FLU_BASE + FLU_FILTER_SIMPLE)
+        r = self.get_api_response('detail?obs_date__ge=2000&dataset_name=flu_shot_clinics&' + FLU_BASE + FLU_FILTER_SIMPLE)
         self.assertEqual(r['meta']['total'], 4)
 
     def test_detail_with_compound_flu_filters_and(self):
-        r = self.get_api_response('detail?dataset_name=flu_shot_clinics&' + FLU_FILTER_COMPOUND_AND)
+        r = self.get_api_response('detail?obs_date__ge=2000&dataset_name=flu_shot_clinics&' + FLU_FILTER_COMPOUND_AND)
         self.assertEqual(r['meta']['total'], 1)
 
     def test_detail_with_compound_flu_filters_or(self):
-        r = self.get_api_response('detail?dataset_name=flu_shot_clinics&' + FLU_FILTER_COMPOUND_OR)
+        r = self.get_api_response('detail?obs_date__ge=2000&dataset_name=flu_shot_clinics&' + FLU_FILTER_COMPOUND_OR)
         self.assertEqual(r['meta']['total'], 13)
 
     def test_detail_with_nested_flu_filters(self):
-        r = self.get_api_response('detail?dataset_name=flu_shot_clinics&' + FLU_BASE + FLU_FILTER_NESTED)
+        r = self.get_api_response('detail?obs_date__ge=2000&dataset_name=flu_shot_clinics&' + FLU_BASE + FLU_FILTER_NESTED)
         self.assertEqual(r['meta']['total'], 4)
 
     # ============================

--- a/tests/points/api_tests.py
+++ b/tests/points/api_tests.py
@@ -235,7 +235,7 @@ class PointAPITests(BasePlenarioTest):
 
     def test_grid_with_simple_tree_filter(self):
         filter_ = 'crimes__filters={"op": "eq", "col": "description", "val": "CREDIT CARD FRAUD"}'
-        r = self.get_api_response('grid?dataset_name=crimes&{}'.format(filter_))
+        r = self.get_api_response('grid?obs_date__ge=2000&dataset_name=crimes&{}'.format(filter_))
         self.assertEqual(len(r['features']), 2)
 
     def test_space_and_time(self):


### PR DESCRIPTION
Both grid and detail violate a guarantee that a user will always be able to filter results with the obs_date param. Tests concerning filters have been adjusted accordingly.