### PR TITLE
Fix validator not updating index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,39 @@ services:
 sudo: required
 dist: trusty
 cache: pip
+env:
+  global:
+  - JOBS_QUEUE=Plenario-Testing-Queue
+  - secure: G1RWlnwPIPSW2XRD7IItotgzTw41IAktyt2VurJwOp3xCIrmeHOtby6ox1x3Ph80Tzp3m3zLENof/sPsgOwRQgUOQ0nScpVGBGsUTAc26LL4SSs+7LGUAohm3EFTHPWU+78ZZMe3njK2fT86XP19FH1CupxgQ1vTpQI1iFChDD0=
+  - secure: bnBfgN5eIAsCVdo+tMhjO88GRfUAEIkD0HFcOMEezP1YQv1bIFU71l5v4aT348RD2kuu6kihWApIqsEe0HjW8u0umPV6aLHuEuUrKGyxwk1x81bhP0KpgQgx+/Qbai4Q6gk+U4TWk713Ezu0j0GJH8jxixvyXgrJjfA/1yvHCdg=
 before_install:
-- pip install celery
 - pip install -r requirements.txt
+- sudo mkdir -p /opt/python/log/
+- sudo chmod 777 /opt/python/log/
+- touch /opt/python/log/worker.log
+- touch /opt/python/log/sender.log
 install:
 - sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'password';"
 - sudo -u postgres psql -c "CREATE DATABASE plenario_test;"
 - sudo -u postgres psql -c "CREATE EXTENSION postgis;" plenario_test
-- celery -A plenario.celery_app worker --loglevel=info &
 - python init_db.py
 script:
-- nosetests tests/points/ tests/shapes/ tests/submission/ -v
+###
+# Something strange is up with our tests
+# running these tests together causes them
+# to error and fail...but they work when
+# run separately. Probably something to
+# do with test fixure setup and tear down
+###
+# Furthermore, don't run the jobs test first.
+# Points (etc?) does some kind of setup that
+# is useful to jobs (it fails otherwise)
+###
+- nosetests tests/points/ -v
+- nosetests tests/shapes/ -v
+- nosetests tests/submission/ -v
+- nosetests tests/jobs -v
+- nosetests tests/utils -v
 deploy:
 - provider: elasticbeanstalk
   access_key_id:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,14 @@ services:
 sudo: required
 dist: trusty
 cache: pip
-env:
-  global:
-  - JOBS_QUEUE=Plenario-Testing-Queue
-  - secure: G1RWlnwPIPSW2XRD7IItotgzTw41IAktyt2VurJwOp3xCIrmeHOtby6ox1x3Ph80Tzp3m3zLENof/sPsgOwRQgUOQ0nScpVGBGsUTAc26LL4SSs+7LGUAohm3EFTHPWU+78ZZMe3njK2fT86XP19FH1CupxgQ1vTpQI1iFChDD0=
-  - secure: bnBfgN5eIAsCVdo+tMhjO88GRfUAEIkD0HFcOMEezP1YQv1bIFU71l5v4aT348RD2kuu6kihWApIqsEe0HjW8u0umPV6aLHuEuUrKGyxwk1x81bhP0KpgQgx+/Qbai4Q6gk+U4TWk713Ezu0j0GJH8jxixvyXgrJjfA/1yvHCdg=
 before_install:
+- pip install celery
 - pip install -r requirements.txt
-- sudo mkdir -p /opt/python/log/
-- sudo chmod 777 /opt/python/log/
-- touch /opt/python/log/worker.log
-- touch /opt/python/log/sender.log
 install:
 - sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'password';"
 - sudo -u postgres psql -c "CREATE DATABASE plenario_test;"
 - sudo -u postgres psql -c "CREATE EXTENSION postgis;" plenario_test
+- celery -A plenario.celery_app worker --loglevel=info &
 - python init_db.py
 script:
 ###
@@ -35,7 +28,7 @@ script:
 # running these tests together causes them
 # to error and fail...but they work when
 # run separately. Probably something to
-# do with test fixure setup and tear down
+# do with test fixture setup and tear down
 ###
 # Furthermore, don't run the jobs test first.
 # Points (etc?) does some kind of setup that

--- a/plenario/utils/model_helpers.py
+++ b/plenario/utils/model_helpers.py
@@ -1,0 +1,150 @@
+"""model_helpers: Just a collection of functions which perform common
+interactions with the models."""
+
+from sqlalchemy.exc import ProgrammingError
+
+from plenario.database import app_engine, session
+from plenario.etl.point import PlenarioETL
+from plenario.etl.shape import ShapeETL
+from plenario.models import MetaTable, ShapeMetadata
+
+
+def add_meta_if_not_exists(app, table_name, post_data, shape=False):
+    """Add a meta record through the post endpoint. Meant for use
+    with tests.
+
+    :param table_name: (string)
+    :param app: (FlaskApp) TestClient instance used to make requests
+    :param post_data: (list) data that is used to make post request
+    :param shape: (bool) designates which meta record to use"""
+
+    if not meta_exists(table_name, shape):
+        shape = 'true' if shape else 'false'
+        app.post('/add?is_shapefile={}'.format(shape), data=post_data)
+
+
+def meta_exists(table_name, shape=False):
+    """Check if a meta record exists for the table name.
+
+    :param table_name: (string)
+    :param shape: (bool) designates which meta table to use
+    :returns: (bool) True if a meta record exists, False if otherwise"""
+
+    meta = 'meta_shape' if shape else 'meta_master'
+    return app_engine.execute("select exists("
+                              "select 1 from {} where dataset_name='{}'"
+                              ")"
+                              .format(meta, table_name)).scalar()
+
+
+def drop_meta_if_exists(table_name, shape=False):
+    """Fetch a meta record for the specified table name.
+
+    :param table_name: (string)
+    :param shape: (bool) designates which meta table to use"""
+
+    if meta_exists(table_name, shape):
+        meta = 'shape' if shape else 'master'
+        app_engine.execute("delete from meta_{} where dataset_name = '{}'"
+                           .format(meta, table_name))
+
+
+def fetch_meta(dataset_name, shape=False):
+    """Fetch a meta record for the specified table name.
+
+    :param dataset_name: (string) table name
+    :param shape: (bool) designates which meta table to use
+    :returns: (Table) SQLAlchemy table object"""
+
+    if shape:
+        return ShapeMetadata.get_by_dataset_name(dataset_name)
+    else:
+        return MetaTable.get_by_dataset_name(dataset_name)
+
+
+def fetch_table(dataset_name, shape=False):
+    """Fetch a table instance for the specified table name.
+
+    :param dataset_name: (string) table name
+    :param shape: (bool) designates which meta table to use
+    :returns: (Table) SQLAlchemy table object"""
+
+    if shape:
+        return ShapeMetadata.get_by_dataset_name(dataset_name).shape_table
+    else:
+        return MetaTable.get_by_dataset_name(dataset_name).point_table
+
+
+def table_exists(table_name):
+    """Make an inexpensive query to the database. It the table does not exist,
+    the query will cause a ProgrammingError.
+
+    :param table_name: (string) table name
+    :returns: (bool) true if the table exists, false otherwise"""
+
+    try:
+        app_engine.execute("select '{}'::regclass".format(table_name))
+        return True
+    except ProgrammingError:
+        return False
+
+
+def drop_table_if_exists(table_name, shape=False):
+    """Meant for use in test suites and nowhere else. Helps to maintain
+    the self-contained nature of unit tests.
+
+    :param table_name: (string) table name
+    :param shape: (bool) designates which meta table to use."""
+
+    if table_exists(table_name):
+        if shape:
+            table = fetch_table(table_name, shape=True)
+            meta = fetch_meta(table_name, shape=True)
+            meta.is_ingested = False
+        else:
+            table = fetch_table(table_name, shape=False)
+        table.drop()
+        session.commit()
+
+
+def add_table_if_not_exists(table_name, shape=False, source=None):
+    """Meant for use in test suites and nowhere else. Helps to maintain
+    the self-contained nature of unit tests.
+
+    :param table_name: (string) table name
+    :param shape: (bool) designates which ETL handles the table
+    :param source: (string) optional path to a local dataset file"""
+
+    if not table_exists(table_name):
+        if shape:
+            meta = fetch_meta(table_name, shape)
+            etl = ShapeETL(meta)
+            etl.meta.is_ingested = False
+            etl.add()
+        else:
+            meta = fetch_meta(table_name, shape)
+            PlenarioETL(meta).add()
+
+
+def fetch_pending_tables(model):
+    """Used in views.py, fetch all records corresponding to tables pending
+    administrator approval. These tables exist in the master tables, but their
+    corresponding records have not been ingested.
+
+    :param model: (class) ORM Class corresponding to a meta table
+    :returns: (list) contains all records for which is_approved is false"""
+
+    query = session.query(model).filter(model.approved_status is not True)
+    return query.all()
+
+
+# def fetch_table_etl_status(model):
+#     """Used in views.py, fetch all records corresponding to tables that have
+#     entered the ETL process. Used to report successful, ongoing, or failed
+#     ETL tasks.
+#
+#     :param model: (class) ORM Class corresponding to a meta table
+#     :returns: (list) contains all records for datasets and ETL status"""
+#
+#     query = session.query(model, ETLTask.status, ETLTask.error)
+#     return query.all()

--- a/tests/points/validator_tests.py
+++ b/tests/points/validator_tests.py
@@ -1,6 +1,9 @@
 import json
 import unittest
 from plenario import create_app
+from plenario.api.validator import Validator
+from plenario.utils.model_helpers import table_exists, add_meta_if_not_exists, add_table_if_not_exists
+from tests.test_fixtures.post_data import roadworks_post_data
 
 
 class TestValidator(unittest.TestCase):
@@ -178,3 +181,17 @@ class TestValidator(unittest.TestCase):
 
         self.assertTrue(len(resp_data['meta']['message']) == 1)
         self.assertIn('invalid keyword', resp_data['meta']['message']['crimes'])
+
+    def test_updates_index_and_validates_correctly(self):
+
+        validator = Validator()
+
+        add_meta_if_not_exists(app=self.test_client,
+                               table_name='roadworks',
+                               post_data=roadworks_post_data,
+                               shape=False)
+        add_table_if_not_exists('roadworks', shape=False)
+
+        validator_result = validator.loads('{"dataset_name": "roadworks"}')
+        self.assertFalse(bool(validator_result.errors))
+        self.assertEqual('roadworks', validator_result.data['dataset_name'])

--- a/tests/test_fixtures/post_data.py
+++ b/tests/test_fixtures/post_data.py
@@ -75,3 +75,30 @@ boundaries_post_data = dict([
     ('update_frequency', u'yearly'), ('contributor_email', u'look@me.com'),
     ('is_shapefile', u'true'), ('dataset_name', u'boundaries_neighborhoods')
 ])
+
+roadworks_post_data = dict([
+    ('dataset_attribution', u'Bristol City Council'),
+    ('col_name_road', u''), ('view_url',
+    u'http://opendata.bristol.gov.uk/api/views/fpdj-qssx/rows'),
+    ('col_name_description', u''), ('col_name_nature_of_works',
+                                    u''),
+    ('dataset_description', u'summary of roadworks extracted'
+                            u'from register today'), ('col_name_lon', u''),
+    ('contributor_name', u'mrmeseeks'), ('update_frequency',
+                                         u'yearly'),
+    ('col_name_status', u''), ('col_name_location',
+                               u'location'),
+    ('col_name_info_today', u''),
+    ('col_name_weather_dependent', u''), ('is_shapefile',
+                                          u'false'),
+    ('col_name_gb_gr_y', u''), ('col_name_gb_gr_x', u''),
+    ('col_name_lat', u''), ('contributor_email',
+                            u'look@me.com'),
+    ('col_name_end_date', u''), ('col_name_severity', u''),
+    ('contributor_organization', u''), ('file_url', u'http://'
+u'opendata.bristol.gov.uk/api/views/fpdj-qssx/rows.csv?accessType=DOWNLOAD'),
+    ('col_name_objectid', u''), ('col_name_start_date',
+                                 u'observed_date'),
+    ('dataset_name', u'roadworks')
+])
+

--- a/tests/test_fixtures/post_data.py
+++ b/tests/test_fixtures/post_data.py
@@ -1,0 +1,77 @@
+# index
+# -----
+# restaurants_post_data (dataset)
+# boundaries_post_data (shapeset)
+
+# post data
+# -----------------------------------------------------------------------------
+
+restaurants_post_data = dict([
+    ('col_name_decisiontargetdate', u''),
+    ('col_name_classificationlabel', u''),
+    ('col_name_publicconsultationenddate', u''),
+    ('col_name_locationtext', u''),
+    ('view_url', u'https://opendata.bristol.gov.uk/api/views/5niz-5v5u/rows'),
+    ('dataset_description', u'Planning applications details for applications '
+                            u'from 2010 to 2014. Locations have been geocoded '
+                            u'based on postcode where available.'),
+    ('col_name_decisionnoticedate', u''),
+    ('col_name_casetext', u''),
+    ('update_frequency', u'yearly'), ('col_name_status', u''),
+    ('col_name_location', u'location'),
+    ('col_name_publicconsultationstartdate', u''),
+    ('contributor_email', u'look@me.com'),
+    ('col_name_decision', u''), ('col_name_decisiontype', u''),
+    ('col_name_organisationuri', u''),
+    ('col_name_appealref', u''),
+    ('col_name_coordinatereferencesystem', u''),
+    ('col_name_appealdecision', u''),
+    ('col_name_geoarealabel', u''),
+    ('col_name_organisationlabel', u''),
+    ('contributor_organization', u''),
+    ('col_name_casereference', u''),
+    ('col_name_latitude', u''),
+    ('col_name_servicetypelabel', u''),
+    ('is_shapefile', u'false'),
+    ('col_name_groundarea', u''), ('col_name_postcode', u''),
+    ('col_name_agent', u''), ('col_name_classificationuri', u''),
+    ('col_name_geoy', u''),
+    ('col_name_geox', u''), ('col_name_uprn', u''),
+    ('col_name_geopointlicencingurl', u''),
+    ('col_name_appealdecisiondate', u''),
+    ('col_name_decisiondate', u''), ('col_name_extractdate', u'observed_date'),
+    ('col_name_servicetypeuri', u''), ('col_name_casedate', u''),
+    ('dataset_attribution', u'Bristol City Council'),
+    ('col_name_caseurl', u''), ('contributor_name', u'mrmeseeks'),
+    ('col_name_publisheruri', u''), ('col_name_geoareauri', u''),
+    ('col_name_postcode_sector', u''),
+    ('file_url', u'https://opendata.bristol.gov.uk/api/views/5niz-5v5u/'
+                 'rows.csv?accessType=DOWNLOAD'),
+    ('col_name_postcode_district', u''),
+    ('col_name_publisherlabel', u''), ('col_name_responsesfor', u''),
+    ('col_name_responsesagainst', u''), ('col_name_longitude', u''),
+    ('dataset_name', u'restaurant_applications')
+])
+
+boundaries_post_data = dict([
+    ('dataset_attribution', u'City of Chicago'), 
+    ('contributor_name', u'mrmeseeks'), 
+    ('view_url', u''),
+    ('file_url', u'https://data.cityofchicago.org/api/geospatial/bbvz-uum9'
+     '?method=export&format=Shapefile'),
+    ('contributor_organization', u''),
+    ('dataset_description', u'Neighborhood'
+                            u'boundaries in Chicago, as developed by'
+                            u'the Office of Tourism. These boundaries'
+                            u'are approximate and names are not'
+                            u'official. The data can be viewed on the'
+                            u'Chicago Data Portal with a web browser.'
+                            u'However, to view or use the files'
+                            u'outside of a web browser, you will need'
+                            u'to use compression software and special'
+                            u'GIS software, such as ESRI ArcGIS'
+                            u'(shapefile) or Google Earth (KML or'
+                            u'KMZ), is required.'),
+    ('update_frequency', u'yearly'), ('contributor_email', u'look@me.com'),
+    ('is_shapefile', u'true'), ('dataset_name', u'boundaries_neighborhoods')
+])

--- a/tests/utils/test_model_helpers.py
+++ b/tests/utils/test_model_helpers.py
@@ -1,0 +1,116 @@
+import unittest
+from plenario import create_app
+from plenario.utils.model_helpers import *
+from tests.test_fixtures.post_data import *
+
+
+class TestModelHelpers(unittest.TestCase):
+
+    def setUp(self):
+        self.app = create_app()
+        self.test_app = self.app.test_client()
+
+    def test_meta_exists(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='restaurant_applications',
+                               post_data=restaurants_post_data,
+                               shape=False)
+        self.assertTrue(meta_exists('restaurant_applications', shape=False))
+
+    def test_meta_exists_bad_arg(self):
+        self.assertFalse(meta_exists('foo', shape=False))
+
+    def test_meta_exists_shape(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='boundaries_neighborhoods',
+                               post_data=boundaries_post_data,
+                               shape=True)
+        self.assertTrue(meta_exists('boundaries_neighborhoods', shape=True))
+
+    def test_meta_exists_shape_bad_arg(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='boundaries_neighborhoods',
+                               post_data=boundaries_post_data,
+                               shape=True)
+        self.assertFalse(meta_exists('foo', shape=True))
+
+    def test_table_exists(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='restaurant_applications',
+                               post_data=restaurants_post_data,
+                               shape=False)
+        add_table_if_not_exists('restaurant_applications')
+        arg = 'restaurant_applications'
+        result = table_exists(arg)
+        self.assertTrue(result)
+
+    def test_table_exists_bad_arg(self):
+        self.assertFalse(table_exists('foo'))
+
+    def test_table_exists_shape(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='boundaries_neighborhoods',
+                               post_data=boundaries_post_data,
+                               shape=True)
+        add_table_if_not_exists('boundaries_neighborhoods', shape=True)
+        self.assertTrue(table_exists('boundaries_neighborhoods'))
+
+    def test_drop_table_if_exists(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='restaurant_applications',
+                               post_data=restaurants_post_data,
+                               shape=False)
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='boundaries_neighborhoods',
+                               post_data=boundaries_post_data,
+                               shape=True)
+        drop_table_if_exists('restaurant_applications', shape=False)
+        drop_table_if_exists('boundaries_neighborhoods', shape=True)
+
+        self.assertFalse(table_exists('restaurant_applications'))
+        self.assertFalse(table_exists('boundaries_neighborhoods'))
+
+    def test_drop_meta_if_exists(self):
+        drop_meta_if_exists('restaurant_applications', shape=False)
+        drop_meta_if_exists('boundaries_neighborhoods', shape=True)
+
+        self.assertFalse(meta_exists('restaurant_applications', shape=False))
+        self.assertFalse(meta_exists('boundaries_neighborhoods', shape=True))
+
+    def test_meta_exists_but_not_table(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='restaurant_applications',
+                               post_data=restaurants_post_data,
+                               shape=False)
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='boundaries_neighborhoods',
+                               post_data=boundaries_post_data,
+                               shape=True)
+        drop_table_if_exists('restaurant_applications', shape=False)
+        drop_table_if_exists('boundaries_neighborhoods', shape=True)
+
+        self.assertTrue(meta_exists('restaurant_applications', shape=False))
+        self.assertTrue(meta_exists('boundaries_neighborhoods', shape=True))
+        self.assertFalse(table_exists('restaurant_applications'))
+        self.assertFalse(table_exists('boundaries_neighborhoods'))
+
+    def test_fetch_meta(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='restaurant_applications',
+                               post_data=restaurants_post_data,
+                               shape=False)
+        meta = fetch_meta('restaurant_applications')
+        self.assertEqual(meta.dataset_name, 'restaurant_applications')
+
+    def test_fetch_table(self):
+        add_meta_if_not_exists(app=self.test_app,
+                               table_name='boundaries_neighborhoods',
+                               post_data=boundaries_post_data,
+                               shape=True)
+        add_table_if_not_exists('boundaries_neighborhoods', shape=True)
+        table = fetch_table('boundaries_neighborhoods', shape=True)
+
+        self.assertEqual(table.name, 'boundaries_neighborhoods')
+
+    # Test: fetch_pending_tables -- difficult to do right now because
+    # of interference from the base test suite.


### PR DESCRIPTION
Came across this bug last night, the validator checks for valid table names with a list it generates when the __class__ is created. Because of this, that list is never updated until Plenario restarts or undergoes an update. The dataset could be added with no problem, but the validator will still reject it with a "not a valid choice" error because of its outdated reference of datasets.