### PR TITLE
Geom validator and "0" value error

### DIFF
--- a/tests/points/validator_tests.py
+++ b/tests/points/validator_tests.py
@@ -7,6 +7,7 @@ from plenario import create_app
 from plenario.database import app_engine
 from plenario.etl.point import PlenarioETL
 from plenario.models import MetaTable
+from api_tests import get_loop_rect
 from tests.test_fixtures.post_data import roadworks_post_data
 
 
@@ -209,6 +210,22 @@ class TestValidator(unittest.TestCase):
 
         resp_data = self.get_json_response_data(query)
         self.assertEqual(len(resp_data['objects']), 24)
+
+    def test_approves_good_geom(self):
+
+        escaped_query_rect = get_loop_rect()
+        query = 'datasets?location_geom__within={}&obs_date__ge={}&obs_date__le={}' \
+            .format(escaped_query_rect, '2015-1-1', '2016-1-1')
+
+        r = self.get_json_response_data(query)
+        self.assertEqual(r['meta']['message'], [])
+
+    def test_rejects_bad_geom(self):
+        bad_geom = "I sure hope I don't pass as a geom"
+        query = 'datasets?location_geom__within={}&obs_date__ge={}&obs_date__le={}' \
+            .format(bad_geom, '2015-1-1', '2016-1-1')
+        r = self.get_json_response_data(query)
+        self.assertEqual(len(r['meta']['message']), 1)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Added geom validator to Marshmallow Validator, fixed a condition that would cause Validator to throw an error if a falsy python value was provided