### PR TITLE
Fix that keeps the footer at the bottom of the page!

### DIFF
--- a/plenario/static/css/custom.css
+++ b/plenario/static/css/custom.css
@@ -1,25 +1,30 @@
 /* Space out content a bit */
 body {
-  padding-bottom: 20px;
-  font-size: 17px;
+    height: 100%;
+    font-size: 17px;
+    padding-bottom: 0;
 }
 
-.label:hover { text-decoration: none; }
+.label:hover {
+    text-decoration: none;
+}
 
 .showmore-content {
     overflow: hidden;
     height: 165px;
 }
 
-.panel-group { margin-bottom: 5px;}
+.panel-group {
+    margin-bottom: 5px;
+}
 
 .panel-heading a {
-  display: block;
+    display: block;
 }
 
 .panel-heading a:hover,
 .panel-heading a:active {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .showmore-content p {
@@ -31,105 +36,172 @@ body {
     margin-top: 10px;
 }
 
-.well h2, .detail-header { margin-top: 0; }
+.well h2, .detail-header {
+    margin-top: 0;
+}
 
-.red { color: red; }
+.red {
+    color: red;
+}
 
-.examples { word-wrap: break-word; }
+.examples {
+    word-wrap: break-word;
+}
 
-.highcharts-sparkline { height: 80px; width: 350px;}
-#detail-chart { height: 150px;}
+.highcharts-sparkline {
+    height: 80px;
+    width: 350px;
+}
+
+#detail-chart {
+    height: 150px;
+}
 
 /* Everything but the jumbotron gets side spacing for mobile first views */
 .header,
 .marketing,
 .footer {
-  padding-left: 15px;
-  padding-right: 15px;
+    padding-left: 15px;
+    padding-right: 15px;
 }
 
 /* Custom page header */
 .header {
-  border-bottom: 1px solid #e5e5e5;
+    border-bottom: 1px solid #e5e5e5;
 }
+
 /* Make the masthead heading the same height as the navigation */
 .header h3 {
-  margin-top: 0;
-  margin-bottom: 0;
-  line-height: 40px;
-  padding-bottom: 19px;
+    margin-top: 0;
+    margin-bottom: 0;
+    line-height: 40px;
+    padding-bottom: 19px;
 }
+
+/*Sticky Footer Code*/
+
+#wrap {
+    min-height: 100%;
+}
+
+#main {
+    overflow: auto;
+    padding-bottom: 4em;
+}
+
+/* must be same height as the footer */
+
+#footer {
+    position: relative;
+    margin-top: -4em;
+    /* negative value of footer height */
+    padding-top: 1em;
+    height: 3em;
+    clear: both;
+    line-height: 1em;
+    text-align: center;
+    color: rgb(80, 80, 80);
+}
+
+/*Opera Fix*/
+
+body:before {
+    content: "";
+    height: 100%;
+    float: left;
+    width: 0;
+    margin-top: -32767px;
+}
+
+/*End Sticky Footer*/
 
 /* Custom page footer */
 .footer {
-  padding-top: 5px;
-  color: #777;
-  border-top: 1px solid #e5e5e5;
-  list-style: none;
-  background-color: #fff;
+    padding-top: 5px;
+    color: #777;
+    border-top: 1px solid #e5e5e5;
+    list-style: none;
+    background-color: #fff;
 }
+
 .footer li {
-  position: relative;
-  display: block;
-  padding: 10px 10px;
-  float: right;
-  font-size: 0.8em;
+    position: relative;
+    display: block;
+    padding: 10px 10px;
+    float: right;
+    font-size: 0.8em;
 }
 
 /* Customize container */
 .container-narrow > hr {
-  margin: 30px 0;
+    margin: 30px 0;
 }
 
 /* Main marketing message and sign up button */
 .jumbotron {
-  text-align: center;
-  border-bottom: 1px solid #e5e5e5;
+    text-align: center;
+    border-bottom: 1px solid #e5e5e5;
 }
+
 .jumbotron .btn {
-  font-size: 21px;
-  padding: 14px 24px;
+    font-size: 21px;
+    padding: 14px 24px;
 }
 
 .jumbotron li {
-  font-size: 16px;
+    font-size: 16px;
 }
 
 /* Responsive: Portrait tablets and up */
 @media screen and (min-width: 768px) {
-  /* Remove the padding we set earlier */
-  .header,
-  .marketing,
-  .footer {
-    padding-left: 0;
-    padding-right: 0;
-  }
-  /* Space out the masthead */
-  .header {
-    margin-bottom: 30px;
-  }
-  /* Remove the bottom border on the jumbotron for visual effect */
-  .jumbotron {
-    border-bottom: 0;
-  }
+    /* Remove the padding we set earlier */
+    .header,
+    .marketing,
+    .footer {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    /* Space out the masthead */
+    .header {
+        margin-bottom: 30px;
+    }
+
+    /* Remove the bottom border on the jumbotron for visual effect */
+    .jumbotron {
+        border-bottom: 0;
+    }
 }
 
-.nowrap { white-space:nowrap; }
+.nowrap {
+    white-space: nowrap;
+}
 
 /* MAP styles */
-#map { min-height: 400px; }
+#map {
+    min-height: 400px;
+}
 
-#list-view { min-height: 100px; }
-#detail-view { min-height: 100px; }
+#list-view {
+    min-height: 100px;
+}
 
-.leaflet-top.leaflet-left{
+#detail-view {
+    min-height: 100px;
+}
+
+.leaflet-top.leaflet-left {
     margin-left: 20px;
 }
+
 .row.filters {
     margin-left: 5px;
 }
 
-#drawing-tools-img { margin-right: 10px; margin-top: 5px;}
+#drawing-tools-img {
+    margin-right: 10px;
+    margin-top: 5px;
+}
 
 /* Dataset table styles */
 .jqsfield {
@@ -139,9 +211,9 @@ body {
 }
 
 .jqstooltip {
-  -webkit-box-sizing: content-box;
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
 }
 
 /* Datepicker styles */
@@ -192,7 +264,7 @@ body {
 
 .ui-datepicker-next:after {
     content: "";
-    border-color: rgba(0,0,0,0) rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) #333;
+    border-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) #333;
     border-image: none;
     border-style: solid;
     border-width: 9px;
@@ -201,9 +273,10 @@ body {
     margin-top: 5px;
     width: 0;
 }
+
 .ui-datepicker-prev:before {
     content: "";
-    border-color: rgba(0,0,0,0) #333 rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
+    border-color: rgba(0, 0, 0, 0) #333 rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
     border-image: none;
     border-style: solid;
     border-width: 9px;
@@ -224,6 +297,7 @@ body {
     text-align: center;
     padding: 3px 0;
 }
+
 .ui-datepicker tbody tr {
     border-bottom: 1px solid #bbb;
 }
@@ -246,8 +320,8 @@ body {
 .legend {
     line-height: 18px;
     color: #555;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    background: rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
     border-radius: 5px;
 }
 
@@ -263,38 +337,39 @@ body {
     opacity: 0.7;
 }
 
-
 /* branding styles */
 .navbar-brand {
-  font-size: 21px;
+    font-size: 21px;
 }
+
 .navbar-brand img {
-	position:relative; 
-	top: -2px; 
-	margin-right: 6px;
-	opacity: 0.85;
+    display: inline;
+    position: relative;
+    top: -2px;
+    margin-right: 6px;
+    opacity: 0.85;
 }
 
 .navbar-brand:hover img {
-	opacity: 1;
+    opacity: 1;
 }
 
 /* examples page */
 .example textarea {
-  max-width: 100%;
-  min-width: 100%;
+    max-width: 100%;
+    min-width: 100%;
 }
 
 .example .try-url {
-  position: relative;
-  top: 38px;
-  left: -2px;
-  margin-top:-36px;
+    position: relative;
+    top: 38px;
+    left: -2px;
+    margin-top: -36px;
 }
 
 .example .label {
-  font-size: 90%;
-  margin-left: 30px;
+    font-size: 90%;
+    margin-left: 30px;
 }
 
 

--- a/plenario/templates/base.html
+++ b/plenario/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" style="height: 100%;">
-  <head>
+<head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
@@ -22,88 +22,100 @@
       <script src="static/js/html5shiv.js"></script>
       <script src="static/js/respond.min.js"></script>
     <![endif]-->
-  </head>
+</head>
 
-  <body style="height: 100%" id="top">
+<body id="top">
+<div id="wrap">
     <div class="navbar navbar-default navbar-static-top" role="navigation">
-      <div class="container-fluid">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/"><img src="/static/images/logo.png" height="22px" width="22px"/>Plenar.io</a>
+        <div class="container-fluid">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="/"><img src="/static/images/logo.png" height="22px"
+                                                      width="22px"/>Plenar.io</a>
+            </div>
+            <div class="navbar-collapse collapse pull-right">
+                <ul class="nav navbar-nav">
+                    <li class="{% if request.path == '/' %}active{% endif %}"><a
+                            href="{{ url_for('views.index') }}">Home</a></li>
+                    <li class="{% if request.path == '/explore' %}active{% endif %}"><a
+                            href="{{ url_for('views.explore_view') }}">Explore</a></li>
+                    <li class="{% if request.path == '/api-docs' %}active{% endif %}"><a
+                            href="{{ url_for('views.api_docs_view') }}">API</a></li>
+                    <li><a href="https://medium.com/plenario-dev">Blog</a></li>
+                    <li class="{% if request.path == '/contribute' %}active{% endif %}"><a
+                            href="{{ url_for('views.user_add_dataset') }}">Add data</a></li>
+                    <li class="{% if request.path == '/about' %}active{% endif %}"><a
+                            href="{{ url_for('views.about_view') }}">About</a></li>
+                    {% if session.get('user_id') %}
+                        <li class="dropdown">
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                Admin <span class="caret"></span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li><a href="{{ url_for('views.view_datasets') }}">View datasets</a></li>
+                                <li><a href="{{ url_for('views.admin_add_dataset') }}">Add a dataset</a></li>
+                                <li><a href="{{ url_for('auth.add_user') }}">Add a user</a></li>
+                                <li><a href="{{ url_for('auth.reset_password') }}">Reset my password</a></li>
+                            </ul>
+                        </li>
+                        <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
+                    {% else %}
+                        <li><a href="{{ url_for('auth.login') }}">Login</a></li>
+                    {% endif %}
+                </ul>
+            </div><!--/.nav-collapse -->
         </div>
-        <div class="navbar-collapse collapse pull-right">
-          <ul class="nav navbar-nav">
-          	<li class="{% if request.path == '/' %}active{% endif %}"><a href="{{ url_for('views.index') }}">Home</a></li>
-            <li class="{% if request.path == '/explore' %}active{% endif %}"><a href="{{ url_for('views.explore_view') }}">Explore</a></li>
-            <li class="{% if request.path == '/api-docs' %}active{% endif %}"><a href="{{ url_for('views.api_docs_view') }}">API</a></li>
-            <li>                                                              <a href="https://medium.com/plenario-dev">Blog</a></li>
-            <li class="{% if request.path == '/contribute' %}active{% endif %}"><a href="{{ url_for('views.user_add_dataset') }}">Add data</a></li>
-            <li class="{% if request.path == '/about' %}active{% endif %}"><a href="{{ url_for('views.about_view') }}">About</a></li>
-            {% if session.get('user_id') %}
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                        Admin <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu">
-                        <li><a href="{{ url_for('views.view_datasets') }}">View datasets</a></li>
-                        <li><a href="{{ url_for('views.admin_add_dataset') }}">Add a dataset</a></li>
-                        <li><a href="{{ url_for('auth.add_user') }}">Add a user</a></li>
-                        <li><a href="{{ url_for('auth.reset_password') }}">Reset my password</a></li>
-                    </ul>
-                </li>
-                <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
-            {% else %}
-                <li><a href="{{ url_for('auth.login') }}">Login</a></li>
-            {% endif %}
-          </ul>
-        </div><!--/.nav-collapse -->
-      </div>
     </div>
-
-    <div class="container-fluid">
-      <div class="row">
-          <div class='col-md-10'>
-            {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                    {% for category, message in messages %}
-                        <div class="alert alert-{{category}} alert-dismissible" role="alert">
-                            <button type="button" class="close" data-dismiss="alert">
-                                <span aria-hidden="true">&times;</span>
-                                <span class="sr-only">Close</span>
-                            </button>
-                            {{ message }}
-                        </div>
-                    {% endfor %}
-                {% endif %}
-            {% endwith %}
-          </div>
-      </div>
-      {% block content %}{% endblock %}
+    <div id="main">
+        <div class="container-fluid">
+            <div class="row">
+                <div class='col-md-10'>
+                    {% with messages = get_flashed_messages(with_categories=true) %}
+                        {% if messages %}
+                            {% for category, message in messages %}
+                                <div class="alert alert-{{ category }} alert-dismissible" role="alert">
+                                    <button type="button" class="close" data-dismiss="alert">
+                                        <span aria-hidden="true">&times;</span>
+                                        <span class="sr-only">Close</span>
+                                    </button>
+                                    {{ message }}
+                                </div>
+                            {% endfor %}
+                        {% endif %}
+                    {% endwith %}
+                </div>
+            </div>
+            {% block content %}{% endblock %}
+        </div>
     </div>
-
+</div>
+<div id="footer">
     <div class='container-fluid'>
-      <div class="footer">
-        <ul>
-          <li><a href="{{ url_for('views.terms_view') }}">Terms</a></li>
-          <li>Built by <a href='https://urbanccd.org/'>UrbanCCD</a>/<a href='http://www.uchicago.edu/'>University of Chicago</a> and <a href='http://datamade.us'>DataMade</a></li>
-        </ul>
-      </div>
+        <div class="footer">
+            <ul>
+                <li><a href="{{ url_for('views.terms_view') }}">Terms</a></li>
+                <li>Built by <a href='https://urbanccd.org/'>UrbanCCD</a>/<a href='http://www.uchicago.edu/'>University
+                    of
+                    Chicago</a> and <a href='http://datamade.us'>DataMade</a></li>
+            </ul>
+        </div>
     </div>
+</div>
 
-    <!-- Bootstrap core JavaScript
-    ================================================== -->
-    <!-- Placed at the end of the document so the pages load faster -->
-    <script src="{{ url_for('static', filename='js/jquery-1.11.1.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/analytics_lib.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/moment.min.js') }}"></script>
-    {% block extra_javascript %}{% endblock %}
+<!-- Bootstrap core JavaScript
+================================================== -->
+<!-- Placed at the end of the document so the pages load faster -->
+<script src="{{ url_for('static', filename='js/jquery-1.11.1.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/analytics_lib.js') }}"></script>
+<script src="{{ url_for('static', filename='js/moment.min.js') }}"></script>
+{% block extra_javascript %}{% endblock %}
 
-  </body>
+</body>
 </html>

--- a/plenario/templates/explore.html
+++ b/plenario/templates/explore.html
@@ -1,77 +1,14 @@
-<!DOCTYPE html>
-<html lang="en" style="height: 100%;">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <title>Plenario Explorer</title>
-
-    <base href="/explore" />
+{% extends 'base.html' %}
+{% block title %}Plenario Explorer{% endblock %}
+{% block extra_styles %}
+    <base href="/explore"/>
     <link href="https://d1hdt0a9t6ezfj.cloudfront.net/assets/vendor.css" rel="stylesheet">
     <link href="https://d1hdt0a9t6ezfj.cloudfront.net/assets/plenario-explorer.css" rel="stylesheet">
-    <!--link href="{{ url_for('static', filename='js/explorer-dist/assets/plenario-explorer.css') }}" rel="stylesheet"-->
-
-  </head>
-
-  <body style="height: 100%" id="top">
-    <div class="navbar navbar-default navbar-static-top" role="navigation">
-      <div class="container-fluid">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/"><img id="plenario-logo" src="/static/images/logo.png" height="22px" width="22px"/>Plenar.io</a>
-        </div>
-        <div class="navbar-collapse collapse pull-right">
-          <ul class="nav navbar-nav">
-          	<li class="{% if request.path == '/' %}active{% endif %}"><a href="{{ url_for('views.index') }}">Home</a></li>
-            <li class="{% if request.path == '/explore' %}active{% endif %}"><a href="{{ url_for('views.explore_view') }}">Explore</a></li>
-            <li class="{% if request.path == '/api-docs' %}active{% endif %}"><a href="{{ url_for('views.api_docs_view') }}">API</a></li>
-            <li class="{% if request.path == '/examples' %}active{% endif %}"><a href="{{ url_for('views.examples_view') }}">Examples</a></li>
-            <li class="{% if request.path == '/contribute' %}active{% endif %}"><a href="{{ url_for('views.user_add_dataset') }}">Add data</a></li>
-            <li class="{% if request.path == '/about' %}active{% endif %}"><a href="{{ url_for('views.about_view') }}">About</a></li>
-            {% if session.get('user_id') %}
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                        Admin <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu">
-                        <li><a href="{{ url_for('views.view_datasets') }}">View datasets</a></li>
-                        <li><a href="{{ url_for('views.admin_add_dataset') }}">Add a dataset</a></li>
-                        <li><a href="{{ url_for('auth.add_user') }}">Add a user</a></li>
-                        <li><a href="{{ url_for('auth.reset_password') }}">Reset my password</a></li>
-                    </ul>
-                </li>
-                <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
-            {% else %}
-                <li><a href="{{ url_for('auth.login') }}">Login</a></li>
-            {% endif %}
-          </ul>
-        </div><!--/.nav-collapse -->
-      </div>
-    </div>
-
-    <div class="container-fluid">
-      <div id="ember-app"> </div>
-    </div>
-
-    <div class='container-fluid'>
-      <div class="footer">
-        <ul>
-          <li><a href="{{ url_for('views.terms_view') }}">Terms</a></li>
-          <li>Built by <a href='https://urbanccd.org/'>UrbanCCD</a>/<a href='http://www.uchicago.edu/'>University of Chicago</a> and <a href='http://datamade.us'>DataMade</a></li>
-        </ul>
-      </div>
-    </div>
-
+{%  endblock %}
+{% block content %}
+    <div id="ember-app"></div>
+{% endblock %}
+{% block extra_javascript %}
     <script type="text/javascript" src="https://d1hdt0a9t6ezfj.cloudfront.net/assets/vendor.js"></script>
     <script type="text/javascript" src="https://d1hdt0a9t6ezfj.cloudfront.net/assets/plenario-explorer.js"></script>
-    <!--script type="text/javascript" src="{{ url_for('static', filename='js/explorer-dist/assets/vendor.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='js/explorer-dist/assets/plenario-explorer.js') }}"></script-->
-
-  </body>
-</html>
+{% endblock %}


### PR DESCRIPTION
This PR includes an addition to base.html to keep the footer at the bottom of the page, nicely and consistently. This fixes the problems we were having with it flying all over the place if the body length did not fill the page.

To implement this footer across the site, I've also restructured explore.html so that it extends base.html for consistency. This was the only page that had wholly its own template without extending base (which resulted in deviations from the rest of the site). **Note that in the future we will need to remove duplicate CSS/JS in plenario-explorer.css in the plenario-explorer project in order to avoid unexpected conflicts.** There aren't any significant ones right now, but I've had to add a few CSS overrides to cancel the old CSS from plenario-explorer.css. There probably won't be any JS conflicts.