### PR TITLE
Fix sentry errors

### DIFF
--- a/plenario/api/common.py
+++ b/plenario/api/common.py
@@ -1,7 +1,7 @@
 import json
 from flask.ext.cache import Cache
 from plenario.settings import CACHE_CONFIG
-from datetime import timedelta, date, datetime
+from datetime import timedelta, date, datetime, time
 from functools import update_wrapper
 from flask import make_response, request, current_app
 import csv
@@ -31,10 +31,13 @@ def unknown_object_json_handler(obj):
         return obj.isoformat()
     elif isinstance(obj, datetime):
         return obj.isoformat()
+    elif isinstance(obj, time):
+        return obj.isoformat()
     elif isinstance(obj, MetaTable):
         return obj.__tablename__
     else:
-        raise ValueError
+        raise ValueError("{0} cannot be parsed into JSON. \n"
+                         "{0} is of type: {1}.".format(obj, type(obj)))
 
 
 def date_json_handler(obj):

--- a/plenario/api/point.py
+++ b/plenario/api/point.py
@@ -257,19 +257,12 @@ def _detail_aggregate(args):
 
         time_counts += [{'count': c, 'datetime': d} for c, d in ts[1:]]
 
-    total_count = sum([c['count'] for c in time_counts])
-
-    if total_count <= 0:
-        return bad_request("Your request doesn't return any results. Try "
-                           "adjusting your time constraint or location "
-                           "parameters.")
-
     resp = None
 
     datatype = args.data['data_type']
     if datatype == 'json':
         resp = json_response_base(args, time_counts, request.args)
-        resp['count'] = total_count
+        resp['count'] = sum([c['count'] for c in time_counts])
         resp = make_response(json.dumps(resp, default=unknown_object_json_handler), 200)
         resp.headers['Content-Type'] = 'application/json'
 
@@ -304,11 +297,6 @@ def _detail(args):
         return internal_error("Failed to fetch records.", ex)
 
     to_remove = ['point_date', 'hash']
-
-    if not result_rows:
-        return bad_request("Your request doesn't return any results. Try "
-                           "adjusting your time constraint or location "
-                           "parameters.")
 
     if data_type == 'json':
         return form_json_detail_response(to_remove, args, result_rows)

--- a/plenario/api/response.py
+++ b/plenario/api/response.py
@@ -87,9 +87,14 @@ def form_csv_detail_response(to_remove, rows):
     to_remove.append('geom')
     remove_columns_from_dict(rows, to_remove)
 
-    # Column headers from arbitrary row,
-    # then the values from all the others
-    csv_resp = [rows[0].keys()] + [row.values() for row in rows]
+    if len(rows) <= 0:
+        csv_resp = [["Sorry! Your query didn't return any results."]]
+        csv_resp += [["Try to modify your date or location parameters."]]
+    else:
+        # Column headers from arbitrary row,
+        # then the values from all the others
+        csv_resp = [rows[0].keys()] + [row.values() for row in rows]
+
     resp = make_response(make_csv(csv_resp), 200)
     dname = request.args.get('dataset_name')
     filedate = datetime.now().strftime('%Y-%m-%d')

--- a/plenario/api/validator.py
+++ b/plenario/api/validator.py
@@ -263,13 +263,19 @@ def validate(validator, request_args):
             field = param.split('__')[0]
             if table is not None:
                 try:
-                    valid_column_condition(table, field, args[param])
+                    param = param.encode()
+                    value = args[param].encode()
+
+                    valid_column_condition(table, field, value)
                     result.data[param] = args[param]
+                except UnicodeEncodeError:
+                    result.errors['EncodeError'] = ['Either your column or your value cannot be encoded into unicode.']
+                    result.errors['EncodeError'] += (param, args[param])
                 except KeyError:
-                    warnings.append('Unused parameter value "{}={}"'.format(param, args[param]))
+                    warnings.append('Unused parameter value "{}={}"'.format(param, value))
                     warnings.append('{} is not a valid column for {}'.format(param, table))
                 except ValueError:
-                    warnings.append('Unused parameter value "{}={}"'.format(param, args[param]))
+                    warnings.append('Unused parameter value "{}={}"'.format(param, value))
                     warnings.append('{} is not a valid value for {}'.format(args[param], param))
 
     # ValidatorResult(dict, dict, list)

--- a/tests/points/api_tests.py
+++ b/tests/points/api_tests.py
@@ -370,7 +370,7 @@ class PointAPITests(BasePlenarioTest):
 
     def test_timeseries_with_a_tree_filter(self):
         endpoint = 'timeseries'
-        query = '?obs_date__ge=2005&agg=year'
+        query = '?obs_date__ge=2005-01-01&agg=year'
         qfilter = '&crimes__filter={"op": "eq", "col": "iucr", "val": 1150}'
 
         resp_data = self.get_api_response(endpoint + query + qfilter)
@@ -378,7 +378,7 @@ class PointAPITests(BasePlenarioTest):
         # Crimes is the only one that gets a filter applied.
         self.assertEqual(resp_data['objects'][0]['count'], 2)
         self.assertEqual(resp_data['objects'][1]['count'], 65)
-        self.assertEqual(resp_data['objects'][2]['count'], 85)
+        self.assertEqual(resp_data['objects'][2]['count'], 88)
 
     def test_timeseries_with_multiple_filters(self):
         endpoint = 'timeseries'


### PR DESCRIPTION
This PR is just me going through Sentry and fixing as many of the issues I found as possible.

__ValueError - plenario.api.common in unknown_object_json_handler__

Detail queries with columns stored as datetime.time objects would break while being converted to json.

__IndexError - plenario.api.response in form_csv_detail_response__

Detail queries which didn't return any records would break when being converted to a CSV file for export.

__Error - plenario.api.common in make_csv__

Not sure how this one never came up before, but detail-aggregate was trying to return CSV results incorrectly. It never converts the JSON into a format that can be written to a CSV file. On top of that, if it didn't crash there it would have definitely crashed on the line after, make_csv does not return a response object with a headers attribute that can be accessed.

__UnicodeEncodeError - plenario.api.validator in validate__

Validator would fail and throw an error when given values which couldn't be encoded into unicode.