### PR TITLE
Aws independant workers

### DIFF
--- a/plenario/api/point.py
+++ b/plenario/api/point.py
@@ -8,6 +8,7 @@ import shapely.wkb
 import copy
 import sqlalchemy
 import traceback
+import warnings
 
 import response as api_response
 
@@ -499,9 +500,12 @@ def cleanup_datadump():
 
 
 def log(msg):
-    # The constant opening and closing is meh, I know. But I'm feeling lazy
-    # right now.
-    logfile = open('/opt/python/log/api.log', "a")
+    try:
+        logfile = open("/opt/python/log/api.log", "a")
+    except IOError:
+        warnings.warn("/opt/python/log/api.log not found - writing to current "
+                      "directory", RuntimeWarning)
+        logfile = open("./api.log", "a")
     logfile.write("{} - {}\n".format(datetime.now(), msg))
     logfile.close()
 

--- a/plenario_worker/clients.py
+++ b/plenario_worker/clients.py
@@ -1,4 +1,5 @@
 import boto3
+import botocore
 from plenario.settings import AWS_ACCESS_KEY, AWS_SECRET_KEY, AWS_REGION_NAME
 from plenario.settings import JOBS_QUEUE
 
@@ -17,11 +18,14 @@ sqs_resource = boto3.resource(
     aws_secret_access_key=AWS_SECRET_KEY
 )
 
-job_queue = sqs_resource.get_queue_by_name(QueueName=JOBS_QUEUE)
-
 autoscaling_client = boto3.client(
     'autoscaling',
     region_name=AWS_REGION_NAME,
     aws_access_key_id=AWS_ACCESS_KEY,
     aws_secret_access_key=AWS_SECRET_KEY
 )
+
+try:
+    job_queue = sqs_resource.get_queue_by_name(QueueName=JOBS_QUEUE)
+except botocore.exceptions.ClientError:
+    job_queue = None

--- a/plenario_worker/utilities.py
+++ b/plenario_worker/utilities.py
@@ -2,6 +2,7 @@
 of the worker threads."""
 
 import traceback
+import warnings
 from datetime import datetime
 from plenario.database import session
 from plenario.models import Workers
@@ -9,7 +10,12 @@ from plenario.settings import AUTOSCALING_GROUP, INSTANCE_ID
 
 
 def log(msg, worker_id):
-    logfile = open('/opt/python/log/worker.log', "a")
+    try:
+        logfile = open('/opt/python/log/worker.log', "a")
+    except IOError:
+        warnings.warn("Failed to write to /opt/python/log/worker.log - "
+                      "writing to current directory.", RuntimeWarning)
+        logfile = open("./worker.log", "a")        
     logfile.write("{} - Worker {}: {}\n".format(datetime.now(), worker_id.ljust(24), msg))
     logfile.close()
 

--- a/tests/points/api_tests.py
+++ b/tests/points/api_tests.py
@@ -349,7 +349,7 @@ class PointAPITests(BasePlenarioTest):
 
     def test_timeseries_with_multiple_datasets(self):
         endpoint = 'timeseries'
-        query = '?obs_date__ge=2000&agg=year&dataset_name__in=flu_shot_clinics,landmarks'
+        query = '?obs_date__ge=2000-08-01&agg=year&dataset_name__in=flu_shot_clinics,landmarks'
 
         resp_data = self.get_api_response(endpoint + query)
 


### PR DESCRIPTION
### Fixes: #260 

### Major Changes:
##### Fix local development experience by creating workers on the fly if no SQS url is provided
Quality of life improvement for developers who want to run plenario locally. runserver.py would fail if it could not find a valid SQS address, which is to say that barely anyone would have been able to get runserver working unless they were familiar with AWS. This solution avoids the use of any queue service if no address is provided and spins up a worker thread in the background as soon as a job is requested. The thread dies as soon as the job is completed.

The tradeoff is that you could possibly overwhelm your local computer by requesting too many jobs, as the number of threads is not limited to four as it is with the original SQS reliant system.

### Minor Changes:
##### Fix query string used in a timeseries test
This test makes a query using the argument `obs_date__ge=2000`, which is valid but unfortunately will resolve to 2000-CURRENTMONTH-CURRENTDAY behind the scenes. Because of this behaviour, the query differs day by day and it just so happens that running the tests today excluded a single record from the test's results. This causes the expected result count to differ from the observed and the travis build to fail.

##### Update log methods write locations to local directory 
Another fix for local development, pages would error obnoxiously because of attempts to write to log files located at `/opt/python/log/`. If the files don't exist, instead of erroring, plenario will issue a warning and create log files in the current directory (wherever runserver.py is running from) instead.

@vivekrs (thanks for bringing this up!! :+1: )
@WillEngler 