### PR TITLE
Fixed typo in index.html

### DIFF
--- a/plenario/templates/index.html
+++ b/plenario/templates/index.html
@@ -27,7 +27,7 @@
     </div>
 
     <h3>Anyone can add data.</h3>
-    <p>Anyone can add datasets to Plenario via the <a href={{ url_for('views.user_add_dataset') }}>Add dataset form</a>Anyone can add datasets to Plenario via the Add Dataset form. You can add any publicly available CSV dataset as long as it includes date and location information; publicly available ESRI Shapefiles enclosed in .zip files can also be added.</p>
+    <p>Anyone can add datasets to Plenario via the <a href={{ url_for('views.user_add_dataset') }}>Add dataset form</a>. You can add any publicly available CSV dataset as long as it includes date and location information; publicly available ESRI Shapefiles enclosed in .zip files can also be added.</p>
 
     <p class="text-center"><a class="btn btn-info btn-lg" href="{{ url_for('views.user_add_dataset') }}">Add a dataset&nbsp;&nbsp;<i class="fa fa-arrow-circle-right"></i></a></p>
 


### PR DESCRIPTION
Fixed typo:
There was a duplicate sentence, probably the result of adding a link to the Add datasets form.

@WillEngler <3