### PR TITLE
Include address in node metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ Werkzeug==0.11.10
 WTForms==2.1
 xlrd==1.0.0
 pyyaml
+geopy==1.11.0

--- a/tests/test_sensor_network/test_sensor_networks.py
+++ b/tests/test_sensor_network/test_sensor_networks.py
@@ -61,6 +61,12 @@ class TestSensorNetworks(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data["meta"]["total"], 1)
 
+    def test_node_metadata_returns_address_in_properties(self):
+        endpoint = '/v1/api/sensor-networks/test_network/nodes/test_node'
+        _, result = self.get_result(endpoint)
+        address = 'Nichols Bridgeway, Chicago, IL 60601, USA'
+        self.assertEqual(result['data'][0]['properties']['address'], address)
+
     def test_sensor_metadata_returns_with_no_args(self):
         response, _ = self.get_result("/v1/api/sensor-networks/test_network/"
                                       "sensors")


### PR DESCRIPTION
This PR extends the metadata returned at the `/nodes` endpoint by including an `address` field derived from a node's latitude and longitude coordinates.