### PR TITLE
Add address column to node metadata

### DIFF
--- a/plenario/models/SensorNetwork.py
+++ b/plenario/models/SensorNetwork.py
@@ -131,6 +131,7 @@ class NodeMeta(postgres_base):
     location = Column(Geometry(geometry_type='POINT', srid=4326))
     sensors = relationship('SensorMeta', secondary='sensor__sensor_to_node')
     info = Column(JSONB)
+    address = Column(String)
 
     column_editable_list = ("sensors", "info")
 

--- a/plenario/sensor_network/api/sensor_networks.py
+++ b/plenario/sensor_network/api/sensor_networks.py
@@ -579,7 +579,6 @@ def format_node_metadata(node):
     coordinates = wkb.loads(bytes(node.location.data))
     longitude = coordinates.x
     latitude = coordinates.y
-    location = GoogleV3().reverse('{}, {}'.format(latitude, longitude))[0]
 
     node_response = {
         "type": "Feature",
@@ -592,7 +591,7 @@ def format_node_metadata(node):
             "network": node.sensor_network,
             "sensors": [sensor.name for sensor in node.sensors],
             "info": node.info,
-            "address": location.address
+            "address": node.address
         },
     }
 

--- a/tests/test_sensor_network/fixtures.py
+++ b/tests/test_sensor_network/fixtures.py
@@ -95,6 +95,7 @@ class Fixtures:
 
         node = NodeMeta(
             id="test_node",
+            address='Nichols Bridgeway, Chicago, IL 60601, USA',
             sensor_network="test_network",
             sensors=[sensor_01, sensor_02, sensor_03],
             location="0101000020E6100000A4A7C821E2E755C07C48F8DEDFF04440",


### PR DESCRIPTION
Instead of determining the address on the fly and hitting Google API's call limit, add address as a column which will be determined by apiary as node metadata is created.