### PR TITLE
Add simple_bbox flag to shapes metadata

### DIFF
--- a/plenario/sensor_network/api/sensor_networks.py
+++ b/plenario/sensor_network/api/sensor_networks.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 
 import boto3
 from flask import request, Response, stream_with_context, jsonify, redirect
-from geopy.geocoders import GoogleV3
 from marshmallow import Schema
 from marshmallow.exceptions import ValidationError
 from marshmallow.fields import Field, List, DateTime, Integer, String, Float
@@ -22,7 +21,6 @@ from plenario.api.validator import valid_tree
 from plenario.database import redshift_session, redshift_engine, redshift_base
 from plenario.settings import S3_BUCKET
 from plenario.utils.helpers import reflect
-
 
 # Cache timeout of 5 minutes
 CACHE_TIMEOUT = 60 * 10

--- a/tests/test_api/test_shape.py
+++ b/tests/test_api/test_shape.py
@@ -303,3 +303,54 @@ class ShapeTests(BasePlenarioTest):
             self.assertFalse(feature['properties'].get('hash'))
             self.assertFalse(feature['properties'].get('ogc_fid'))
             self.assertTrue(feature['properties'].get('count'))
+
+    def test_shape_metadata_with_simple_bbox(self):
+        geojson_query = '''
+        {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {},
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                  [
+                    [
+                      -87.63999938964844,
+                      41.686758404529186
+                    ],
+                    [
+                      -87.57545471191406,
+                      41.686758404529186
+                    ],
+                    [
+                      -87.57545471191406,
+                      41.70008933705676
+                    ],
+                    [
+                      -87.63999938964844,
+                      41.70008933705676
+                    ],
+                    [
+                      -87.63999938964844,
+                      41.686758404529186
+                    ]
+                  ]
+                ]
+              }
+            }
+          ]
+        }
+        '''
+
+        escaped_geojson_query = urllib.parse.quote(geojson_query)
+
+        url = '/v1/api/shapes?simple_bbox=True&location_geom__within=%s'
+        url %= escaped_geojson_query
+
+        response = self.app.get(url)
+
+        data = json.loads(bytes.decode(response.data))
+
+        self.assertEqual(len(data['objects']), 3)


### PR DESCRIPTION
##### Enable simple_box query for /shapes

Enable a cheaper query that is analogous to what `/datasets` responds with. With this flag enabled, `/shapes` will return metadata records of shape datasets if their bounding boxes intersect with the query geom. It will _not_ attempt to count the number of shapes, instead returning the total number of shapes in the shape dataset.

`GET /v1/api/shapes?simple_bbox=True&location_geom__within={...}`
