### PR TITLE
#315

### DIFF
--- a/plenario/api/blueprints.py
+++ b/plenario/api/blueprints.py
@@ -8,9 +8,10 @@ from plenario.sensor_network.api.sensor_networks import check, get_aggregations,
     get_network_map, get_network_metadata, get_node_download, get_node_metadata, get_observation_nearest, \
     get_observations, get_observations_download, get_sensor_metadata
 from .common import cache, make_cache_key
-from .point import datadump_view, dataset_fields, detail, detail_aggregate, get_job_view, grid, meta, timeseries
+from .point import datadump_view, dataset_fields, detail, detail_aggregate, get_job_view, grid, meta
 from .sensor import weather, weather_fill, weather_stations
 from .shape import aggregate_point_data, export_shape, get_all_shape_datasets
+from .timeseries import timeseries
 
 
 api = Blueprint('api', __name__)

--- a/plenario/api/fields.py
+++ b/plenario/api/fields.py
@@ -1,0 +1,43 @@
+import json
+
+from dateutil import parser
+from plenario.api.common import make_fragment_str, extract_first_geometry_fragment
+from plenario.models import MetaTable
+from marshmallow.fields import Field
+from marshmallow.exceptions import ValidationError
+
+
+class DateTime(Field):
+    def _serialize(self, value, attr, obj):
+        return value.isoformat()
+
+    def _deserialize(self, value, attr, data):
+        try:
+            return parser.parse(value)
+        except ValueError:
+            raise ValidationError('{} does not contain a date'.format(value))
+
+
+class Geometry(Field):
+
+    def _serialize(self, value, attr, obj):
+        return json.loads(value)
+
+    def _deserialize(self, value, attr, data):
+        try:
+            return make_fragment_str(extract_first_geometry_fragment(value))
+        except (ValueError, AttributeError):
+            raise ValidationError('Invalid geom: {}'.format(value))
+
+
+class Pointset(Field):
+
+    def _serialize(self, value, attr, obj):
+        return value.name
+
+    def _deserialize(self, value, attr, data):
+        try:
+            return MetaTable.get_by_dataset_name(value).point_table
+        except AttributeError:
+            raise ValidationError('{} is not a valid dataset'.format(value))
+

--- a/plenario/api/fields.py
+++ b/plenario/api/fields.py
@@ -3,11 +3,13 @@ import json
 from dateutil import parser
 from plenario.api.common import make_fragment_str, extract_first_geometry_fragment
 from plenario.models import MetaTable
-from marshmallow.fields import Field
+from marshmallow import utils
+from marshmallow.fields import Field, List
 from marshmallow.exceptions import ValidationError
 
 
 class DateTime(Field):
+
     def _serialize(self, value, attr, obj):
         return value.isoformat()
 
@@ -21,6 +23,8 @@ class DateTime(Field):
 class Geometry(Field):
 
     def _serialize(self, value, attr, obj):
+        if value is None:
+            return None
         return json.loads(value)
 
     def _deserialize(self, value, attr, data):
@@ -33,6 +37,8 @@ class Geometry(Field):
 class Pointset(Field):
 
     def _serialize(self, value, attr, obj):
+        if value is None:
+            return None
         return value.name
 
     def _deserialize(self, value, attr, data):
@@ -41,3 +47,31 @@ class Pointset(Field):
         except AttributeError:
             raise ValidationError('{} is not a valid dataset'.format(value))
 
+
+class Commalist(List):
+
+    def _serialize(self, value, attr, obj):
+        if value is None:
+            return None
+        if utils.is_collection(value):
+            return [self.container._serialize(each, attr, obj) for each in value]
+        return [self.container._serialize(value, attr, obj)]
+
+    def _deserialize(self, value, attr, data):
+        result = []
+        errors = {}
+
+        if type(value) == str:
+            value = value.split(',')
+
+        for idx, each in enumerate(value):
+            try:
+                result.append(self.container.deserialize(each))
+            except ValidationError as e:
+                result.append(e.data)
+                errors.update({idx: e.messages})
+
+        if errors:
+            raise ValidationError(errors, data=result)
+
+        return result

--- a/plenario/api/response.py
+++ b/plenario/api/response.py
@@ -14,12 +14,16 @@ from plenario.models import ShapeMetadata
 from plenario.utils.ogr2ogr import OgrExport
 
 
-def make_error(msg, status_code):
+def make_error(msg, status_code, arguments=None):
+
+    if not arguments:
+        arguments = request.args
+
     resp = {
         'meta': {
             'status': 'error',
             'message': msg,
-            'query': request.args
+            'query': arguments
         },
         'objects': [],
     }

--- a/plenario/api/response.py
+++ b/plenario/api/response.py
@@ -227,48 +227,6 @@ def detail_response(query_result, query_args):
         return form_geojson_detail_response(to_remove, query_result)
 
 
-def timeseries_response(query_result, query_args):
-    resp = json_response_base(query_args, query_result, query_args.data)
-
-    datatype = query_args.data['data_type']
-    if datatype == 'json':
-        resp = make_response(json.dumps(resp, default=unknown_object_json_handler), 200)
-        resp.headers['Content-Type'] = 'application/json'
-    elif datatype == 'csv':
-
-        # response format
-        # temporal_group,dataset_name_1,dataset_name_2
-        # 2014-02-24 00:00:00,235,653
-        # 2014-03-03 00:00:00,156,624
-
-        fields = ['temporal_group']
-        for o in resp['objects']:
-            fields.append(o['dataset_name'])
-
-        csv_resp = []
-        i = 0
-        for k, g in groupby(resp['objects'], key=itemgetter('dataset_name')):
-            l_g = list(g)[0]
-
-            j = 0
-            for row in l_g['items']:
-                # first iteration, populate the first column with temporal_groups
-                if i == 0:
-                    csv_resp.append([row['datetime']])
-                csv_resp[j].append(row['count'])
-                j += 1
-            i += 1
-
-        csv_resp.insert(0, fields)
-        csv_resp = make_csv(csv_resp)
-        resp = make_response(csv_resp, 200)
-        resp.headers['Content-Type'] = 'text/csv'
-        filedate = datetime.now().strftime('%Y-%m-%d')
-        resp.headers['Content-Disposition'] = 'attachment; filename=%s.csv' % filedate
-
-    return resp
-
-
 # Shape Endpoint Responses ====================================================
 
 def aggregate_point_data_response(data_type, rows, dataset_names):

--- a/plenario/api/timeseries.py
+++ b/plenario/api/timeseries.py
@@ -3,23 +3,25 @@ import re
 
 from datetime import datetime, timedelta
 from flask import request, jsonify
+from itertools import groupby
+from operator import itemgetter
 from marshmallow import Schema
-from marshmallow.decorators import post_load
+from marshmallow.decorators import pre_dump, post_load
 from marshmallow.fields import Str, List
 from marshmallow.validate import OneOf
 
 from plenario.api.common import crossdomain, cache, CACHE_TIMEOUT, make_cache_key
 from plenario.api.condition_builder import parse_tree
-from plenario.api.fields import Geometry, Pointset, DateTime
-from plenario.api.response import make_error
+from plenario.api.fields import Geometry, Pointset, DateTime, Commalist
+from plenario.api.response import make_error, make_csv, make_response
 from plenario.api.validator import has_tree_filters
 from plenario.models import MetaTable
 
 
 class TimeseriesValidator(Schema):
     agg = Str(default='week', validate=OneOf({'day', 'week', 'month', 'quarter', 'year'}))
-    dataset_name = Pointset()
-    dataset_name__in = List(Pointset, default=lambda: list())
+    dataset_name = Pointset(default=None)
+    dataset_name__in = Commalist(Pointset(), default=lambda: list())
     location_geom__within = Geometry(default=None)
     obs_date__ge = DateTime(default=lambda: datetime.now())
     obs_date__le = DateTime(default=lambda: datetime.now() - timedelta(days=90))
@@ -35,31 +37,45 @@ class TimeseriesValidator(Schema):
                     data[name] = field.default
         return data
 
+    @pre_dump
+    def defaults(self, data):
+        for name, field in self.fields.items():
+            if name not in data:
+                if callable(field.default):
+                    data[name] = field.default()
+                else:
+                    data[name] = field.default
+        return data
+
 
 @cache.cached(timeout=CACHE_TIMEOUT, key_prefix=make_cache_key)
 @crossdomain(origin='*')
 def timeseries():
     validator = TimeseriesValidator()
+
     deserialized_arguments = validator.load(request.args)
+    serialized_arguments = json.loads(validator.dumps(deserialized_arguments.data).data)
 
     if deserialized_arguments.errors:
-        return make_error(deserialized_arguments.errors, 400, deserialized_arguments.data)
+        return make_error(deserialized_arguments.errors, 400, serialized_arguments)
 
     qargs = deserialized_arguments.data
 
     agg = qargs['agg']
+    data_type = qargs['data_type']
     geom = qargs['location_geom__within']
-    pointset = [qargs['dataset_name']]
+    pointset = qargs['dataset_name']
     pointsets = qargs['dataset_name__in']
     start_date = qargs['obs_date__ge']
     end_date = qargs['obs_date__le']
 
     ctrees = {}
+    raw_ctrees = {}
 
-    if has_tree_filters(qargs):
+    if has_tree_filters(request.args):
         # Timeseries is a little tricky. If there aren't filters,
         # it would be ridiculous to build a condition tree for every one.
-        for field, value in list(qargs.items()):
+        for field, value in list(request.args.items()):
             if 'filter' in field:
                 # This pattern matches the last occurrence of the '__' pattern.
                 # Prevents an error that is caused by dataset names with trailing
@@ -67,19 +83,61 @@ def timeseries():
                 tablename = re.split(r'__(?!_)', field)[0]
                 metarecord = MetaTable.get_by_dataset_name(tablename)
                 pt = metarecord.point_table
-                ctrees[pt.name] = parse_tree(pt, value)
+                ctrees[pt.name] = parse_tree(pt, json.loads(value))
+                raw_ctrees[pt.name] = json.loads(value)
 
-    point_set_names = [p.name for p in pointsets + pointset]
+    point_set_names = [p.name for p in pointsets + [pointset] if p is not None]
+    if not point_set_names:
+        point_set_names = MetaTable.index()
+
     results = MetaTable.timeseries_all(point_set_names, agg, start_date, end_date, geom, ctrees)
 
     payload = {
         'meta': {
             'message': [],
-            'query': json.loads(validator.dumps(deserialized_arguments.data).data),
+            'query': serialized_arguments,
             'status': 'ok',
             'total': len(results)
         },
         'objects': results
     }
 
-    return jsonify(payload)
+    if ctrees:
+        payload['meta']['query']['filters'] = raw_ctrees
+
+    if data_type == 'json':
+        return jsonify(payload)
+
+    elif data_type == 'csv':
+
+        # response format
+        # temporal_group,dataset_name_1,dataset_name_2
+        # 2014-02-24 00:00:00,235,653
+        # 2014-03-03 00:00:00,156,624
+
+        fields = ['temporal_group']
+        for o in payload['objects']:
+            fields.append(o['dataset_name'])
+
+        csv_resp = []
+        i = 0
+        for k, g in groupby(payload['objects'], key=itemgetter('dataset_name')):
+            l_g = list(g)[0]
+
+            j = 0
+            for row in l_g['items']:
+                # first iteration, populate the first column with temporal_groups
+                if i == 0:
+                    csv_resp.append([row['datetime']])
+                csv_resp[j].append(row['count'])
+                j += 1
+            i += 1
+
+        csv_resp.insert(0, fields)
+        csv_resp = make_csv(csv_resp)
+        resp = make_response(csv_resp, 200)
+        resp.headers['Content-Type'] = 'text/csv'
+        filedate = datetime.now().strftime('%Y-%m-%d')
+        resp.headers['Content-Disposition'] = 'attachment; filename=%s.csv' % filedate
+
+        return resp

--- a/plenario/api/timeseries.py
+++ b/plenario/api/timeseries.py
@@ -43,7 +43,7 @@ def timeseries():
     deserialized_arguments = validator.load(request.args)
 
     if deserialized_arguments.errors:
-        return make_error(deserialized_arguments.error, 400, deserialized_arguments.data)
+        return make_error(deserialized_arguments.errors, 400, deserialized_arguments.data)
 
     qargs = deserialized_arguments.data
 

--- a/plenario/api/timeseries.py
+++ b/plenario/api/timeseries.py
@@ -1,0 +1,85 @@
+import json
+import re
+
+from datetime import datetime, timedelta
+from flask import request, jsonify
+from marshmallow import Schema
+from marshmallow.decorators import post_load
+from marshmallow.fields import Str, List
+from marshmallow.validate import OneOf
+
+from plenario.api.common import crossdomain, cache, CACHE_TIMEOUT, make_cache_key
+from plenario.api.condition_builder import parse_tree
+from plenario.api.fields import Geometry, Pointset, DateTime
+from plenario.api.response import make_error
+from plenario.api.validator import has_tree_filters
+from plenario.models import MetaTable
+
+
+class TimeseriesValidator(Schema):
+    agg = Str(default='week', validate=OneOf({'day', 'week', 'month', 'quarter', 'year'}))
+    dataset_name = Pointset()
+    dataset_name__in = List(Pointset, default=lambda: list())
+    location_geom__within = Geometry(default=None)
+    obs_date__ge = DateTime(default=lambda: datetime.now())
+    obs_date__le = DateTime(default=lambda: datetime.now() - timedelta(days=90))
+    data_type = Str(default='json', validate=OneOf({'csv', 'json'}))
+
+    @post_load
+    def defaults(self, data):
+        for name, field in self.fields.items():
+            if name not in data:
+                if callable(field.default):
+                    data[name] = field.default()
+                else:
+                    data[name] = field.default
+        return data
+
+
+@cache.cached(timeout=CACHE_TIMEOUT, key_prefix=make_cache_key)
+@crossdomain(origin='*')
+def timeseries():
+    validator = TimeseriesValidator()
+    deserialized_arguments = validator.load(request.args)
+
+    if deserialized_arguments.errors:
+        return make_error(deserialized_arguments.error, 400, deserialized_arguments.data)
+
+    qargs = deserialized_arguments.data
+
+    agg = qargs['agg']
+    geom = qargs['location_geom__within']
+    pointset = [qargs['dataset_name']]
+    pointsets = qargs['dataset_name__in']
+    start_date = qargs['obs_date__ge']
+    end_date = qargs['obs_date__le']
+
+    ctrees = {}
+
+    if has_tree_filters(qargs):
+        # Timeseries is a little tricky. If there aren't filters,
+        # it would be ridiculous to build a condition tree for every one.
+        for field, value in list(qargs.items()):
+            if 'filter' in field:
+                # This pattern matches the last occurrence of the '__' pattern.
+                # Prevents an error that is caused by dataset names with trailing
+                # underscores.
+                tablename = re.split(r'__(?!_)', field)[0]
+                metarecord = MetaTable.get_by_dataset_name(tablename)
+                pt = metarecord.point_table
+                ctrees[pt.name] = parse_tree(pt, value)
+
+    point_set_names = [p.name for p in pointsets + pointset]
+    results = MetaTable.timeseries_all(point_set_names, agg, start_date, end_date, geom, ctrees)
+
+    payload = {
+        'meta': {
+            'message': [],
+            'query': json.loads(validator.dumps(deserialized_arguments.data).data),
+            'status': 'ok',
+            'total': len(results)
+        },
+        'objects': results
+    }
+
+    return jsonify(payload)

--- a/plenario/server.py
+++ b/plenario/server.py
@@ -42,6 +42,7 @@ def create_app():
 
     app = Flask(__name__)
     app.config.from_object('plenario.settings')
+    app.config['JSON_SORT_KEYS'] = False
     app.url_map.strict_slashes = False
     login_manager.init_app(app)
     login_manager.login_view = 'auth.login'

--- a/tests/test_api/test_point.py
+++ b/tests/test_api/test_point.py
@@ -356,6 +356,7 @@ class PointAPITests(BasePlenarioTest):
         query = '?obs_date__ge=2000-08-01&agg=year&dataset_name__in=flu_shot_clinics,landmarks'
 
         resp_data = self.get_api_response(endpoint + query)
+        print(resp_data)
 
         self.assertEqual(resp_data['objects'][0]['count'], 65)
         self.assertEqual(resp_data['objects'][1]['count'], 149)
@@ -366,7 +367,7 @@ class PointAPITests(BasePlenarioTest):
 
         resp_data = self.get_api_response(endpoint + query)
 
-        self.assertIn('Invalid table name: landmarkz.', resp_data['meta']['message']['dataset_name__in'])
+        self.assertIn('landmarkz', resp_data['meta']['message']['dataset_name__in']['1'][0])
 
     # ================================
     # /timeseries with condition trees


### PR DESCRIPTION
Timeseries queries which yielded no results would create their own Response objects that could not be serialized into JSON.

```
# If there aren't any table names, it causes an error down the code. Better
# to return and inform them that the request wouldn't have found anything.
if not table_names:
   return api_response.bad_request('Your request does not return any results. Try '
                                    'adjusting your time constraint or location '
                                    'parameters.')
```

Stupid error for stupid code. I broke the `/timeseries` route out into it's own file to make it easier to maintain. I'd like to do this for all of the routes eventually but my god the churn.

Fixes #315 